### PR TITLE
Add ESLint to test

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Build Tools",
   "main": "index.js",
   "scripts": {
-    "test": "mocha --compilers js:babel-core/register"
+    "test": "mocha --compilers js:babel-core/register && eslint ."
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
It only makes sense that ESLint is a part of the tests, as we want
people to follow the linting rules.